### PR TITLE
fix(examples): produce javadoc for examples

### DIFF
--- a/modules/examples/pom.xml
+++ b/modules/examples/pom.xml
@@ -13,10 +13,6 @@
     <packaging>jar</packaging>
     <name>Code Examples</name>
 
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-    </properties>
-
     <dependencies>
         <!-- There should be a dependency for each module whose request example class exists in this "examples" module. Add 
             new "dependency" entries here as needed when you add a request examples class for a new service. Note: the "artifactId" values 
@@ -30,10 +26,6 @@
             <groupId>com.ibm.cloud</groupId>
             <artifactId>cd-tekton-pipeline</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/modules/examples/pom.xml
+++ b/modules/examples/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Signed-off-by: Omar Al Bastami <omar.albastami@ibm.com>

## PR summary
The current build is failing due to code example javadocs not generating. Modified the example/pom.xml to enable building javadocs for code examples.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->