### PR TITLE
Fix versioning

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-10-15T19:07:42Z",
+  "generated_at": "2025-08-08T16:27:26Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "8d204a8e6f883c0691207b5eed52ab2889568f71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 233,
+        "line_number": 234,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Java client library to interact with the [IBM Cloud Continuous Delivery Tool
 
 <!-- toc -->
 
-- [IBM Cloud Continuous Delivery Java SDK Version 2.0.3](#ibm-cloud-continuous-delivery-java-sdk-version-190)
+- [IBM Cloud Continuous Delivery Java SDK Version 2.0.3](#ibm-cloud-continuous-delivery-java-sdk-version-203)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
   - [Prerequisites](#prerequisites)

--- a/build/.travis.settings.xml
+++ b/build/.travis.settings.xml
@@ -3,9 +3,9 @@
     xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.OSSRH_USERNAME}</username>
-            <password>${env.OSSRH_PASSWORD}</password>
+            <id>central</id>
+            <username>${env.CP_USERNAME}</username>
+            <password>${env.CP_PASSWORD}</password>
         </server>
     </servers>
 </settings>

--- a/modules/cd-tekton-pipeline/src/main/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/CdTektonPipeline.java
+++ b/modules/cd-tekton-pipeline/src/main/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/CdTektonPipeline.java
@@ -119,7 +119,7 @@ public class CdTektonPipeline extends BaseService {
 
     m.put("ca-tor", "https://api.ca-tor.devops.cloud.ibm.com/pipeline/v2"); // The host URL for Tekton Pipeline Service in the ca-tor region.
 
-    m.put("ca-mon", "https://api.ca-mon.devops.cloud.ibm.com/pipeline/v2"); // Montreal (ca-mon) is a limited-availability region and not generally available. The host URL for Tekton Pipeline Service in the ca-mon region.
+    m.put("ca-mon", "https://api.ca-mon.devops.cloud.ibm.com/pipeline/v2"); // Montreal (ca-mon) is a limited availability region and not generally available. The host URL for Tekton Pipeline Service in the ca-mon region.
 
     m.put("br-sao", "https://api.br-sao.devops.cloud.ibm.com/pipeline/v2"); // The host URL for Tekton Pipeline Service in the br-sao region.
     _regionalEndpoints = Collections.unmodifiableMap(m);
@@ -935,6 +935,9 @@ public class CdTektonPipeline extends BaseService {
     }
     if (createTektonPipelineTriggerOptions.enableEventsFromForks() != null) {
       contentJson.addProperty("enable_events_from_forks", createTektonPipelineTriggerOptions.enableEventsFromForks());
+    }
+    if (createTektonPipelineTriggerOptions.disableDraftEvents() != null) {
+      contentJson.addProperty("disable_draft_events", createTektonPipelineTriggerOptions.disableDraftEvents());
     }
     builder.bodyJson(contentJson);
     ResponseConverter<Trigger> responseConverter =

--- a/modules/cd-tekton-pipeline/src/main/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/CreateTektonPipelineTriggerOptions.java
+++ b/modules/cd-tekton-pipeline/src/main/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/CreateTektonPipelineTriggerOptions.java
@@ -67,6 +67,7 @@ public class CreateTektonPipelineTriggerOptions extends GenericModel {
   protected String filter;
   protected Boolean favorite;
   protected Boolean enableEventsFromForks;
+  protected Boolean disableDraftEvents;
 
   /**
    * Builder.
@@ -89,6 +90,7 @@ public class CreateTektonPipelineTriggerOptions extends GenericModel {
     private String filter;
     private Boolean favorite;
     private Boolean enableEventsFromForks;
+    private Boolean disableDraftEvents;
 
     /**
      * Instantiates a new Builder from an existing CreateTektonPipelineTriggerOptions instance.
@@ -113,6 +115,7 @@ public class CreateTektonPipelineTriggerOptions extends GenericModel {
       this.filter = createTektonPipelineTriggerOptions.filter;
       this.favorite = createTektonPipelineTriggerOptions.favorite;
       this.enableEventsFromForks = createTektonPipelineTriggerOptions.enableEventsFromForks;
+      this.disableDraftEvents = createTektonPipelineTriggerOptions.disableDraftEvents;
     }
 
     /**
@@ -365,6 +368,17 @@ public class CreateTektonPipelineTriggerOptions extends GenericModel {
       this.enableEventsFromForks = enableEventsFromForks;
       return this;
     }
+
+    /**
+     * Set the disableDraftEvents.
+     *
+     * @param disableDraftEvents the disableDraftEvents
+     * @return the CreateTektonPipelineTriggerOptions builder
+     */
+    public Builder disableDraftEvents(Boolean disableDraftEvents) {
+      this.disableDraftEvents = disableDraftEvents;
+      return this;
+    }
   }
 
   protected CreateTektonPipelineTriggerOptions() { }
@@ -395,6 +409,7 @@ public class CreateTektonPipelineTriggerOptions extends GenericModel {
     filter = builder.filter;
     favorite = builder.favorite;
     enableEventsFromForks = builder.enableEventsFromForks;
+    disableDraftEvents = builder.disableDraftEvents;
   }
 
   /**
@@ -606,6 +621,17 @@ public class CreateTektonPipelineTriggerOptions extends GenericModel {
    */
   public Boolean enableEventsFromForks() {
     return enableEventsFromForks;
+  }
+
+  /**
+   * Gets the disableDraftEvents.
+   *
+   * Prevent new pipeline runs from being triggered by events from draft pull requests.
+   *
+   * @return the disableDraftEvents
+   */
+  public Boolean disableDraftEvents() {
+    return disableDraftEvents;
   }
 }
 

--- a/modules/cd-tekton-pipeline/src/main/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/Trigger.java
+++ b/modules/cd-tekton-pipeline/src/main/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/Trigger.java
@@ -60,6 +60,8 @@ public class Trigger extends GenericModel {
   protected Boolean limitWaitingRuns;
   @SerializedName("enable_events_from_forks")
   protected Boolean enableEventsFromForks;
+  @SerializedName("disable_draft_events")
+  protected Boolean disableDraftEvents;
   protected TriggerSource source;
   protected List<String> events;
   protected String filter;
@@ -216,6 +218,17 @@ public class Trigger extends GenericModel {
    */
   public Boolean isEnableEventsFromForks() {
     return enableEventsFromForks;
+  }
+
+  /**
+   * Gets the disableDraftEvents.
+   *
+   * Prevent new pipeline runs from being triggered by events from draft pull requests.
+   *
+   * @return the disableDraftEvents
+   */
+  public Boolean isDisableDraftEvents() {
+    return disableDraftEvents;
   }
 
   /**

--- a/modules/cd-tekton-pipeline/src/main/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/TriggerPatch.java
+++ b/modules/cd-tekton-pipeline/src/main/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/TriggerPatch.java
@@ -73,6 +73,8 @@ public class TriggerPatch extends GenericModel {
   protected Boolean favorite;
   @SerializedName("enable_events_from_forks")
   protected Boolean enableEventsFromForks;
+  @SerializedName("disable_draft_events")
+  protected Boolean disableDraftEvents;
 
   /**
    * Builder.
@@ -94,6 +96,7 @@ public class TriggerPatch extends GenericModel {
     private String filter;
     private Boolean favorite;
     private Boolean enableEventsFromForks;
+    private Boolean disableDraftEvents;
 
     /**
      * Instantiates a new Builder from an existing TriggerPatch instance.
@@ -117,6 +120,7 @@ public class TriggerPatch extends GenericModel {
       this.filter = triggerPatch.filter;
       this.favorite = triggerPatch.favorite;
       this.enableEventsFromForks = triggerPatch.enableEventsFromForks;
+      this.disableDraftEvents = triggerPatch.disableDraftEvents;
     }
 
     /**
@@ -343,6 +347,17 @@ public class TriggerPatch extends GenericModel {
       this.enableEventsFromForks = enableEventsFromForks;
       return this;
     }
+
+    /**
+     * Set the disableDraftEvents.
+     *
+     * @param disableDraftEvents the disableDraftEvents
+     * @return the TriggerPatch builder
+     */
+    public Builder disableDraftEvents(Boolean disableDraftEvents) {
+      this.disableDraftEvents = disableDraftEvents;
+      return this;
+    }
   }
 
   protected TriggerPatch() { }
@@ -364,6 +379,7 @@ public class TriggerPatch extends GenericModel {
     filter = builder.filter;
     favorite = builder.favorite;
     enableEventsFromForks = builder.enableEventsFromForks;
+    disableDraftEvents = builder.disableDraftEvents;
   }
 
   /**
@@ -563,6 +579,17 @@ public class TriggerPatch extends GenericModel {
    */
   public Boolean enableEventsFromForks() {
     return enableEventsFromForks;
+  }
+
+  /**
+   * Gets the disableDraftEvents.
+   *
+   * Prevent new pipeline runs from being triggered by events from draft pull requests.
+   *
+   * @return the disableDraftEvents
+   */
+  public Boolean disableDraftEvents() {
+    return disableDraftEvents;
   }
 
   /**

--- a/modules/cd-tekton-pipeline/src/test/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/CdTektonPipelineTest.java
+++ b/modules/cd-tekton-pipeline/src/test/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/CdTektonPipelineTest.java
@@ -1576,6 +1576,7 @@ public class CdTektonPipelineTest {
       .filter("testString")
       .favorite(false)
       .enableEventsFromForks(false)
+      .disableDraftEvents(false)
       .build();
 
     // Invoke createTektonPipelineTrigger() with a valid options model and verify the result
@@ -1721,6 +1722,7 @@ public class CdTektonPipelineTest {
       .filter("header['x-github-event'] == 'push' && body.ref == 'refs/heads/main'")
       .favorite(false)
       .enableEventsFromForks(false)
+      .disableDraftEvents(false)
       .build();
     Map<String, Object> triggerPatchModelAsPatch = triggerPatchModel.asPatch();
 

--- a/modules/cd-tekton-pipeline/src/test/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/CreateTektonPipelineTriggerOptionsTest.java
+++ b/modules/cd-tekton-pipeline/src/test/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/CreateTektonPipelineTriggerOptionsTest.java
@@ -87,6 +87,7 @@ public class CreateTektonPipelineTriggerOptionsTest {
       .filter("header['x-github-event'] == 'push' && body.ref == 'refs/heads/main'")
       .favorite(false)
       .enableEventsFromForks(false)
+      .disableDraftEvents(false)
       .build();
     assertEquals(createTektonPipelineTriggerOptionsModel.pipelineId(), "94619026-912b-4d92-8f51-6c74f0692d90");
     assertEquals(createTektonPipelineTriggerOptionsModel.type(), "manual");
@@ -105,6 +106,7 @@ public class CreateTektonPipelineTriggerOptionsTest {
     assertEquals(createTektonPipelineTriggerOptionsModel.filter(), "header['x-github-event'] == 'push' && body.ref == 'refs/heads/main'");
     assertEquals(createTektonPipelineTriggerOptionsModel.favorite(), Boolean.valueOf(false));
     assertEquals(createTektonPipelineTriggerOptionsModel.enableEventsFromForks(), Boolean.valueOf(false));
+    assertEquals(createTektonPipelineTriggerOptionsModel.disableDraftEvents(), Boolean.valueOf(false));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/cd-tekton-pipeline/src/test/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/TriggerPatchTest.java
+++ b/modules/cd-tekton-pipeline/src/test/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/TriggerPatchTest.java
@@ -87,6 +87,7 @@ public class TriggerPatchTest {
       .filter("header['x-github-event'] == 'push' && body.ref == 'refs/heads/main'")
       .favorite(false)
       .enableEventsFromForks(false)
+      .disableDraftEvents(false)
       .build();
     assertEquals(triggerPatchModel.type(), "manual");
     assertEquals(triggerPatchModel.name(), "start-deploy");
@@ -104,6 +105,7 @@ public class TriggerPatchTest {
     assertEquals(triggerPatchModel.filter(), "header['x-github-event'] == 'push' && body.ref == 'refs/heads/main'");
     assertEquals(triggerPatchModel.favorite(), Boolean.valueOf(false));
     assertEquals(triggerPatchModel.enableEventsFromForks(), Boolean.valueOf(false));
+    assertEquals(triggerPatchModel.disableDraftEvents(), Boolean.valueOf(false));
 
     String json = TestUtilities.serialize(triggerPatchModel);
 
@@ -123,6 +125,7 @@ public class TriggerPatchTest {
     assertEquals(triggerPatchModelNew.filter(), "header['x-github-event'] == 'push' && body.ref == 'refs/heads/main'");
     assertEquals(triggerPatchModelNew.favorite(), Boolean.valueOf(false));
     assertEquals(triggerPatchModelNew.enableEventsFromForks(), Boolean.valueOf(false));
+    assertEquals(triggerPatchModelNew.disableDraftEvents(), Boolean.valueOf(false));
   }
   @Test
   public void testTriggerPatchAsPatch() throws Throwable {
@@ -166,6 +169,7 @@ public class TriggerPatchTest {
       .filter("header['x-github-event'] == 'push' && body.ref == 'refs/heads/main'")
       .favorite(false)
       .enableEventsFromForks(false)
+      .disableDraftEvents(false)
       .build();
 
     Map<String, Object> mergePatch = triggerPatchModel.asPatch();
@@ -186,6 +190,7 @@ public class TriggerPatchTest {
     assertEquals(mergePatch.get("filter"), "header['x-github-event'] == 'push' && body.ref == 'refs/heads/main'");
     assertTrue(mergePatch.containsKey("favorite"));
     assertTrue(mergePatch.containsKey("enable_events_from_forks"));
+    assertTrue(mergePatch.containsKey("disable_draft_events"));
   }
 
 }

--- a/modules/cd-tekton-pipeline/src/test/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/TriggerScmTriggerTest.java
+++ b/modules/cd-tekton-pipeline/src/test/java/com/ibm/cloud/continuous_delivery/cd_tekton_pipeline/v2/model/TriggerScmTriggerTest.java
@@ -50,6 +50,7 @@ public class TriggerScmTriggerTest {
     assertNull(triggerScmTriggerModel.isFavorite());
     assertNull(triggerScmTriggerModel.isLimitWaitingRuns());
     assertNull(triggerScmTriggerModel.isEnableEventsFromForks());
+    assertNull(triggerScmTriggerModel.isDisableDraftEvents());
     assertNull(triggerScmTriggerModel.getSource());
     assertNull(triggerScmTriggerModel.getEvents());
     assertNull(triggerScmTriggerModel.getFilter());

--- a/modules/cd-toolchain/src/main/java/com/ibm/cloud/continuous_delivery/cd_toolchain/v2/CdToolchain.java
+++ b/modules/cd-toolchain/src/main/java/com/ibm/cloud/continuous_delivery/cd_toolchain/v2/CdToolchain.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2025.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -81,6 +81,8 @@ public class CdToolchain extends BaseService {
     m.put("au-syd", "https://api.au-syd.devops.cloud.ibm.com/toolchain/v2"); // The toolchain API endpoint in the au-syd region
 
     m.put("ca-tor", "https://api.ca-tor.devops.cloud.ibm.com/toolchain/v2"); // The toolchain API endpoint in the ca-tor region
+
+    m.put("ca-mon", "https://api.ca-mon.devops.cloud.ibm.com/toolchain/v2"); // Montreal (ca-mon) is a limited-availability region and not generally available. The toolchain API endpoint in the ca-mon region
 
     m.put("br-sao", "https://api.br-sao.devops.cloud.ibm.com/toolchain/v2"); // The toolchain API endpoint in the br-sao region
 

--- a/modules/cd-toolchain/src/test/java/com/ibm/cloud/continuous_delivery/cd_toolchain/v2/CdToolchainTest.java
+++ b/modules/cd-toolchain/src/test/java/com/ibm/cloud/continuous_delivery/cd_toolchain/v2/CdToolchainTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2025.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -88,6 +88,7 @@ public class CdToolchainTest {
     assertEquals(CdToolchain.getServiceUrlForRegion("jp-tok"), "https://api.jp-tok.devops.cloud.ibm.com/toolchain/v2");
     assertEquals(CdToolchain.getServiceUrlForRegion("au-syd"), "https://api.au-syd.devops.cloud.ibm.com/toolchain/v2");
     assertEquals(CdToolchain.getServiceUrlForRegion("ca-tor"), "https://api.ca-tor.devops.cloud.ibm.com/toolchain/v2");
+    assertEquals(CdToolchain.getServiceUrlForRegion("ca-mon"), "https://api.ca-mon.devops.cloud.ibm.com/toolchain/v2");
     assertEquals(CdToolchain.getServiceUrlForRegion("br-sao"), "https://api.br-sao.devops.cloud.ibm.com/toolchain/v2");
     assertEquals(CdToolchain.getServiceUrlForRegion("eu-es"), "https://api.eu-es.devops.cloud.ibm.com/toolchain/v2");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <surefire-version>3.1.2</surefire-version>
         <jacoco-plugin-version>0.8.10</jacoco-plugin-version>
         <maven-deploy-plugin-version>3.1.1</maven-deploy-plugin-version>
-        <nexus-staging-plugin-version>1.6.13</nexus-staging-plugin-version>
+        <central-publish-plugin-version>0.8.0</central-publish-plugin-version>
         <maven-gpg-plugin-version>3.1.0</maven-gpg-plugin-version>
         <maven-source-plugin-version>3.3.0</maven-source-plugin-version>
         <maven-shade-plugin-version>3.5.1</maven-shade-plugin-version>
@@ -212,9 +212,9 @@
                     <version>${maven-deploy-plugin-version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>${nexus-staging-plugin-version}</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${central-publish-plugin-version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -499,23 +499,21 @@
                     <!-- We don't deploy snapshot releases -->
                 </snapshotRepository>
                 <repository>
-                    <!-- This is where the nexus staging plugin will publish artifacts -->
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                    <!-- This is where the central publishing plugin will publish artifacts -->
+                    <id>central</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
                 </repository>
             </distributionManagement>
 
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
## PR summary
Attempting to fix the versioning of the SDK as a v3.0.0 release was erroneously created due to bad commit messages. This PR rolls back to commit 2f00803, then adds two recent changes on top:
- Add support for the disable_draft_events option on Git triggers
- Adding support for ca-mon region in Toolchains

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No
