### PR TITLE
chore: ignore checkstyle update in renovate due to JDK21 requirement

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
     {
       "matchManagers": ["github-actions"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["com.puppycrawl.tools:checkstyle"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## PR summary
The checkstyle update to v13 would require moving minimal support up to JDK21. Due to effort involved ignoring this update for the time being in renovate config


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->